### PR TITLE
修复喵喵吸收器的命名空间

### DIFF
--- a/common/src/main/resources/data/toneko/recipe/neko_aggregator.json
+++ b/common/src/main/resources/data/toneko/recipe/neko_aggregator.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "N": {
-      "item": "neko_collector"
+      "item": "toneko:neko_collector"
     },
     "C": {
       "item": "toneko:catnip"


### PR DESCRIPTION
启动时报错：
Unknown registry key in ResourceKey[minecraft:root / minecraft:item]: minecraft:neko_collector
其实是 neko_collector 前面没加MOD的命名空间导致去原版找了（）