### PR TITLE
feat: auto-trigger getDown pose after crouching for 3 seconds

### DIFF
--- a/common/src/main/java/org/cneko/toneko/common/mod/client/events/ClientTickEvent.java
+++ b/common/src/main/java/org/cneko/toneko/common/mod/client/events/ClientTickEvent.java
@@ -74,6 +74,16 @@ public class ClientTickEvent {
 
 
     private static int tick = 0;
+
+    // Tracks how many consecutive ticks the local player has been crouching
+    private static int crouchTicks = 0;
+    // Cooldown after auto-cancel to prevent immediate re-trigger
+    private static int crouchCooldown = 0;
+    // Threshold: 3 seconds at 20 ticks/s
+    private static final int CROUCH_THRESHOLD = 60;
+    // Cooldown duration after cancelling pose via crouch-release
+    private static final int CROUCH_COOLDOWN_TICKS = 40;
+
     public static void onTick(Minecraft client) {
         TickTasks.executeDefaultClient();
         // 寻找16格内的生物
@@ -88,6 +98,34 @@ public class ClientTickEvent {
                     Entity entity = entry.getKey();
                     return entity == null || entity.distanceTo(p) > 16;
                 });
+            }
+
+            // Auto-trigger getDown pose after crouching for 3 seconds (issue #125)
+            if (p instanceof org.cneko.toneko.common.mod.entities.INeko neko && neko.isNeko()) {
+                if (crouchCooldown > 0) {
+                    crouchCooldown--;
+                }
+
+                if (p.isCrouching()) {
+                    crouchTicks++;
+                    if (crouchTicks == CROUCH_THRESHOLD) {
+                        // Trigger getDown pose
+                        p.connection.sendUnsignedCommand("neko getDown");
+                        crouchTicks = 0;
+                    }
+                } else {
+                    crouchTicks = 0;
+                    // If player released crouch while getDown is active, cancel the pose
+                    if (crouchCooldown == 0 && ClientEntityPoseManager.contains(p) &&
+                            ClientEntityPoseManager.getPose(p) == Pose.SWIMMING) {
+                        p.connection.sendUnsignedCommand("neko getDown");
+                        crouchCooldown = CROUCH_COOLDOWN_TICKS;
+                    }
+                }
+            } else {
+                // Not a neko: reset counters
+                crouchTicks = 0;
+                crouchCooldown = 0;
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds an auto-trigger for the `getDown` pose when a neko player crouches continuously for 3 seconds
- Releasing crouch while the pose is active cancels it automatically, matching the toggle behavior of the existing command
- A 40-tick cooldown after cancellation prevents spam-triggering, addressing the server-kick concern raised in issue #125

## Why this matters

The existing key-binding for `getDown` repeats on hold, which can cause command spam and trigger anti-spam kicks on some servers (#125). This change provides a crouch-based alternative that fires only once at the 3-second threshold.

## Testing

- Crouch for under 3 seconds as a neko: no pose change
- Crouch continuously for 3 seconds as a neko: getDown pose activates
- Release crouch while getDown is active: pose cancels
- Crouch rapidly: cooldown prevents re-trigger spam
- Log in as a non-neko player and crouch: no effect (isNeko guard)
- Use existing GET_DOWN_KEY binding: still works independently

Fixes #125
